### PR TITLE
0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 Changelog
 =========
 
-## 0.8.1
-- Added aarch64 (ARM64) release builds for Linux and macOS.
+## 0.8.2
 - Added Debian (`.deb`) packages to releases, for both x86_64 and aarch64, alongside the existing RPMs.
+
+## 0.8.1
+- Added aarch64 (ARM64) release builds for Linux and macOS, including an aarch64 RPM.
 - Bumped `pbkdf2` to 0.13 and `sha-crypt` to 0.6, migrating to the rewritten `password-hash` 0.6 API.
 - Updated all package dependencies.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "pwgen2"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pwgen2"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 authors = ["Nicolas Embriz <nbari@tequila.io>"]
 description = "password generator"


### PR DESCRIPTION
Release 0.8.2.

- Add Debian (`.deb`) packages to releases, for both x86_64 and aarch64, alongside the existing RPMs.

Also includes the previously-merged 0.8.1 work (aarch64 builds, pbkdf2 0.13 / sha-crypt 0.6, dependency updates).